### PR TITLE
Use pkg-config to find dependencies.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,13 @@ else()
             GIT_TAG           v2.6.2
             INSTALL_COMMAND   ""
             )
+        ExternalProject_Get_property(libkqueue SOURCE_DIR)
+        ExternalProject_Get_property(libkqueue BINARY_DIR)
+        # set the variables that find_package() would set:
+        set(LibKQueue_INCLUDE_DIR ${SOURCE_DIR})
+        set(LibKQueue_LIBRARIES ${BINARY_DIR}/libkqueue.a)
+        # redundant:
+        set(LibKQueue_LIBRARY_LDFLAGS "")
     else()
         find_package(LibKQueue 2.6.2 REQUIRED)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 project(relaunchd)
+
+# add our own module repository to CMake's search path:
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules ${CMAKE_MODULE_PATH} )
 
 include(ExternalProject)
 include(CheckIncludeFiles)
@@ -15,17 +18,23 @@ if (USE_PRIVATE_DEPENDENCIES)
         GIT_TAG           0.8.1
         INSTALL_COMMAND   ""
         )
+else()
+    find_package(LibUCL 0.8.1 REQUIRED)
 endif()
 
 CHECK_INCLUDE_FILES(sys/event.h HAVE_SYS_EVENT_H)
 
 if(HAVE_SYS_EVENT_H)
-elseif(USE_PRIVATE_DEPENDENCIES)
-    ExternalProject_Add(libkqueue
-        GIT_REPOSITORY    https://github.com/mheily/libkqueue.git
-        GIT_TAG           v2.6.2
-        INSTALL_COMMAND   ""
-        )
+else()
+    if(USE_PRIVATE_DEPENDENCIES)
+        ExternalProject_Add(libkqueue
+            GIT_REPOSITORY    https://github.com/mheily/libkqueue.git
+            GIT_TAG           v2.6.2
+            INSTALL_COMMAND   ""
+            )
+    else()
+        find_package(LibKQueue 2.6.2 REQUIRED)
+    endif()
 endif()
 
 add_subdirectory(src)

--- a/cmake/modules/FindLibKQueue.cmake
+++ b/cmake/modules/FindLibKQueue.cmake
@@ -1,0 +1,40 @@
+# interface module for libkqueue's pkg-config file
+
+set(PKG_CONFIG_USE_CMAKE_PREFIX_PATH ON)
+
+include(FindPkgConfig)
+include(FindPackageHandleStandardArgs)
+include(FeatureSummary)
+
+pkg_check_modules(PKG_LibKQueue libkqueue)
+
+if(PKG_LibKQueue_FOUND)
+    set(LibKQueue_DEFINITIONS ${PKG_LibKQueue_CFLAGS_OTHER})
+    set(LibKQueue_VERSION ${PKG_LibKQueue_VERSION})
+    # NB: we could use ${LibKQueue_INCLUDE_DIR if libkqueue's .pc file set its 'includedir' 
+    # directive to its actual include directory, instead of using the 'Cflags' directive!
+    set(LibKQueue_INCLUDE_DIR ${PKG_LibKQueue_INCLUDE_DIRS})
+    set(LibKQueue_LIBRARIES ${PKG_LibKQueue_LIBRARIES})
+    if(PKG_LibKQueue_LIBRARY_DIRS)
+        set(LibKQueue_LIBRARY_LDFLAGS "-L${PKG_LibKQueue_LIBRARY_DIRS}")
+    else()
+        set(LibKQueue_LIBRARY_LDFLAGS "")
+    endif()
+endif()
+
+find_package_handle_standard_args(LibKQueue
+    FOUND_VAR
+        LibKQueue_FOUND
+    REQUIRED_VARS
+        LibKQueue_INCLUDE_DIR
+    VERSION_VAR
+        LibKQueue_VERSION
+)
+
+mark_as_advanced(LibKQueue_INCLUDE_DIR)
+
+set_package_properties(LibKQueue PROPERTIES
+                     DESCRIPTION "A library that emulates FreeBSD kqueue(2) on other platforms"
+                     TYPE REQUIRED
+                     URL "https://github.com/mheily/libkqueue")
+

--- a/cmake/modules/FindLibUCL.cmake
+++ b/cmake/modules/FindLibUCL.cmake
@@ -1,0 +1,40 @@
+# interface module for libucl's pkg-config file
+
+set(PKG_CONFIG_USE_CMAKE_PREFIX_PATH ON)
+
+include(FindPkgConfig)
+include(FindPackageHandleStandardArgs)
+include(FeatureSummary)
+
+pkg_check_modules(PKG_LibUCL libucl)
+
+if(PKG_LibUCL_FOUND)
+    set(LibUCL_DEFINITIONS ${PKG_LibUCL_CFLAGS_OTHER})
+    set(LibUCL_VERSION ${PKG_LibUCL_VERSION})
+    # NB: we could use ${LibUCL_INCLUDE_DIR if libucl's .pc file set its 'includedir' 
+    # directive to its actual include directory, instead of using the 'Cflags' directive!
+    set(LibUCL_INCLUDE_DIR ${PKG_LibUCL_INCLUDE_DIRS})
+    set(LibUCL_LIBRARIES ${PKG_LibUCL_LIBRARIES})
+    if(PKG_LibUCL_LIBRARY_DIRS)
+        set(LibUCL_LIBRARY_LDFLAGS "-L${PKG_LibUCL_LIBRARY_DIRS}")
+    else()
+        set(LibUCL_LIBRARY_LDFLAGS "")
+    endif()
+endif()
+
+find_package_handle_standard_args(LibUCL
+    FOUND_VAR
+        LibUCL_FOUND
+    REQUIRED_VARS
+        LibUCL_INCLUDE_DIR
+    VERSION_VAR
+        LibUCL_VERSION
+)
+
+mark_as_advanced(LibUCL_INCLUDE_DIR)
+
+set_package_properties(LibUCL PROPERTIES
+                     DESCRIPTION "A Universal Configuration Library"
+                     TYPE REQUIRED
+                     URL "https://github.com/vstakhov/libucl")
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,7 @@ if (USE_PRIVATE_DEPENDENCIES)
     # Answer: yes, you know where they get checked out w.r.t. the build dir (CMAKE_BINARY_DIR)
     ExternalProject_Get_property(libucl SOURCE_DIR)
     # libucl is used only by launchd so add its header repository only to the launchd target
-    target_include_directories(launchd "${SOURCE_DIR}/include")
+    target_include_directories(launchd PRIVATE "${SOURCE_DIR}/include")
     ExternalProject_Get_property(libucl BINARY_DIR)
     target_link_libraries(launchd "${BINARY_DIR}/libucl.a")
 else()
@@ -49,20 +49,10 @@ endif()
 
 if(HAVE_SYS_EVENT_H)
 else()
-    if (USE_PRIVATE_DEPENDENCIES)
-        # TODO: Is there a better way to access the CMake variables in this external project?
-        ExternalProject_Get_property(libkqueue SOURCE_DIR)
-        set(LIBKQUEUE_SOURCE_DIR ${SOURCE_DIR})
-        include_directories("${LIBKQUEUE_SOURCE_DIR}/include")
-        ExternalProject_Get_property(libkqueue BINARY_DIR)
-        set(LIBKQUEUE_BINARY_DIR ${BINARY_DIR})
-        target_link_libraries(launchd "${LIBKQUEUE_BINARY_DIR}/libkqueue.a")
-    else()
-        target_link_libraries(launchd "${LibKQueue_LIBRARIES}")
-        # add the libkqueue header and library directories to all targets in this source directory:
-        include_directories("${LibKQueue_INCLUDE_DIR}")
-        add_link_options("${LibKQueue_LIBRARY_LDFLAGS}")
-    endif()
+    target_link_libraries(launchd "${LibKQueue_LIBRARIES}")
+    # add the libkqueue header and library directories to all targets in this source directory:
+    include_directories("${LibKQueue_INCLUDE_DIR}")
+    add_link_options("${LibKQueue_LIBRARY_LDFLAGS}")
 endif()
 
 # for asprintf() in glibc
@@ -103,10 +93,5 @@ target_link_libraries(launchctl launch pthread)
 
 if(HAVE_SYS_EVENT_H)
 else()
-    if (USE_PRIVATE_DEPENDENCIES)
-        # TODO: Is there a better way to access the CMake variables in this external project?
-        target_link_libraries(launchctl "${LIBKQUEUE_BINARY_DIR}/libkqueue.a")
-    else()
-        target_link_libraries(launchctl "${LibKQueue_LIBRARIES}")
-    endif()
+    target_link_libraries(launchctl "${LibKQueue_LIBRARIES}")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,12 +36,15 @@ target_link_libraries(launchd launch pthread)
 
 if (USE_PRIVATE_DEPENDENCIES)
     # TODO: Is there a better way to access the CMake variables in this external project?
+    # Answer: yes, you know where they get checked out w.r.t. the build dir (CMAKE_BINARY_DIR)
     ExternalProject_Get_property(libucl SOURCE_DIR)
-    include_directories(launchd "${SOURCE_DIR}/include")
+    # libucl is used only by launchd so add its header repository only to the launchd target
+    target_include_directories(launchd "${SOURCE_DIR}/include")
     ExternalProject_Get_property(libucl BINARY_DIR)
     target_link_libraries(launchd "${BINARY_DIR}/libucl.a")
 else()
-    target_link_libraries(launchd "-lucl")
+    target_link_options(launchd PRIVATE "${LibUCL_LIBRARY_LDFLAGS}")
+    target_link_libraries(launchd "${LibUCL_LIBRARIES}")
 endif()
 
 if(HAVE_SYS_EVENT_H)
@@ -50,13 +53,15 @@ else()
         # TODO: Is there a better way to access the CMake variables in this external project?
         ExternalProject_Get_property(libkqueue SOURCE_DIR)
         set(LIBKQUEUE_SOURCE_DIR ${SOURCE_DIR})
-        include_directories(launchd "${LIBKQUEUE_SOURCE_DIR}/include")
+        include_directories("${LIBKQUEUE_SOURCE_DIR}/include")
         ExternalProject_Get_property(libkqueue BINARY_DIR)
         set(LIBKQUEUE_BINARY_DIR ${BINARY_DIR})
         target_link_libraries(launchd "${LIBKQUEUE_BINARY_DIR}/libkqueue.a")
     else()
-        target_link_libraries(launchd "-lkqueue")
-        include_directories(launchd "-I/usr/include/kqueue") # TODO: can we get this from pkgconfig instead?
+        target_link_libraries(launchd "${LibKQueue_LIBRARIES}")
+        # add the libkqueue header and library directories to all targets in this source directory:
+        include_directories("${LibKQueue_INCLUDE_DIR}")
+        add_link_options("${LibKQueue_LIBRARY_LDFLAGS}")
     endif()
 endif()
 
@@ -102,6 +107,6 @@ else()
         # TODO: Is there a better way to access the CMake variables in this external project?
         target_link_libraries(launchctl "${LIBKQUEUE_BINARY_DIR}/libkqueue.a")
     else()
-        target_link_libraries(launchctl "-lkqueue")
+        target_link_libraries(launchctl "${LibKQueue_LIBRARIES}")
     endif()
 endif()


### PR DESCRIPTION
Introduces CMake "find modules" that interface with pkg-config
to find libucl and libkqueue. Also moves dependency finding
logic to the toplevel CMake file, as is conventional.