### PR TITLE
Build system refinements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,5 +34,8 @@ else()
         find_package(LibKQueue 2.6.2 REQUIRED)
     endif()
 endif()
+if(NOT USE_PRIVATE_DEPENDENCIES)
+    find_package(TinyXML2 9.0.0 REQUIRED)
+endif()
 
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,16 +8,26 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wall -Wextra")
 
 check_include_files(sys/limits.h, HAVE_SYS_LIMITS_H)
 
-add_library(launch STATIC 
+set(LAUNCH_SRC
         channel.h channel.cc
         log.cc log.h
         util.h
         options.cc options.h
         signal.cc signal.h
-        state_file.cc state_file.hpp
-        ../vendor/tinyxml2.cpp ../vendor/tinyxml2.h
-        )
+        state_file.cc state_file.hpp)
+if (USE_PRIVATE_DEPENDENCIES)
+    set(LAUNCH_SRC ${LAUNCH_SRC}
+        ../vendor/tinyxml2.cpp ../vendor/tinyxml2.h)
+endif()
+add_library(launch STATIC ${LAUNCH_SRC})
 
+if (NOT USE_PRIVATE_DEPENDENCIES)
+    # we register libtinyxml2 as a public dependency of liblaunch
+    # instead of including the tinyxml2 sources in it; also
+    # add the tinyxml2 include directory to all targets in the current dir.
+    target_link_libraries(launch PUBLIC tinyxml2::tinyxml2)
+    include_directories(tinyxml2::tinyxml2)
+endif()
 if (CMAKE_SYSTEM_NAME MATCHES Linux)
     # this makes adding libthread explicitly (below) redundant
     # but adding just that library is not necessarily sufficient

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,9 +58,6 @@ target_link_libraries(launchd launch pthread)
 #endif()
 
 check_symbol_exists(sys_signame "signal.h" HAVE_SYS_SIGNAME)
-if(HAVE_SYS_SIGNAME)
-    target_compile_definitions(launchd PRIVATE -DHAVE_SYS_SIGNAME)
-endif()
 
 if(HAVE_SYS_EVENT_H)
 else()

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -19,6 +19,7 @@
 #define PREFIX      "${CMAKE_INSTALL_PREFIX}"
 #define VARDIR		"${VARDIR}"
 #define PKGSTATEDIR "${PKGSTATEDIR}"
+#cmakedefine01 HAVE_SYS_SIGNAME
 
 #define CONFIG_H_
 #endif

--- a/src/job.cc
+++ b/src/job.cc
@@ -25,6 +25,7 @@
 #include <sys/param.h>
 #endif
 
+#include "config.h"
 #include "calendar.h"
 #include "job.h"
 #include "log.h"

--- a/src/launchctl.cc
+++ b/src/launchctl.cc
@@ -16,6 +16,7 @@
 
 #include <err.h>
 #include <iostream>
+#include <filesystem>
 
 #include "channel.h"
 #include "options.h"


### PR DESCRIPTION
Support building against an installed libTinyXML2 and pass `HAVE_SYS_SIGNAME` through the generated `config.h`